### PR TITLE
feature/SY2026-54-PickingRawPage

### DIFF
--- a/src/pages/field/PickingRawPage/App_PickingRawPage.jsx
+++ b/src/pages/field/PickingRawPage/App_PickingRawPage.jsx
@@ -1,0 +1,700 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+const fallbackPicking = {
+  id: "picking-raw-01",
+  manufacturer: "현대 제철",
+  material: "SS275",
+  specText: "22 x 2,438 x 6,096",
+  weightText: "7,698 kg",
+  duration: "6m",
+  expectedDurationText: "6m",
+  expectedDurationMinutes: 6,
+  to: {
+    zone: "Position 2",
+    time: "",
+  },
+  layout: {
+    highlightedSlot: "2",
+    slots: ["1", "2", "3", "4"],
+    wallLabel: "벽",
+    equipmentLabel: "설비",
+  },
+  pickingOrder: 2,
+  totalPickingCount: 4,
+  isLastPicking: false,
+};
+
+const formatNowTime = () => {
+  const now = new Date();
+  const hh = String(now.getHours()).padStart(2, "0");
+  const mm = String(now.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+};
+
+const parseTimeStringToMinutes = (timeText) => {
+  const match = String(timeText ?? "").match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) return null;
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) return null;
+  return hours * 60 + minutes;
+};
+
+const addMinutesToTime = (timeText, minutesToAdd = 0) => {
+  const baseMinutes = parseTimeStringToMinutes(timeText);
+  if (baseMinutes === null) return "";
+
+  const normalized =
+    (((baseMinutes + Number(minutesToAdd || 0)) % (24 * 60)) + 24 * 60) %
+    (24 * 60);
+
+  const hh = String(Math.floor(normalized / 60)).padStart(2, "0");
+  const mm = String(normalized % 60).padStart(2, "0");
+  return `${hh}:${mm}`;
+};
+
+const extractSlotNumber = (value) => {
+  const match = String(value ?? "").match(/(\d+)/);
+  return match ? match[1] : "";
+};
+
+const parseDurationMinutes = (value) => {
+  const raw = String(value ?? "").trim();
+  if (!raw) return 0;
+
+  const hourMatches = [...raw.matchAll(/(\d+)\s*h/gi)];
+  const minuteMatches = [...raw.matchAll(/(\d+)\s*m/gi)];
+
+  if (hourMatches.length || minuteMatches.length) {
+    const hours = hourMatches.reduce(
+      (sum, match) => sum + Number(match[1] || 0),
+      0
+    );
+    const minutes = minuteMatches.reduce(
+      (sum, match) => sum + Number(match[1] || 0),
+      0
+    );
+    return hours * 60 + minutes;
+  }
+
+  const plainNumber = raw.match(/(\d+)/);
+  return plainNumber ? Number(plainNumber[1]) : 0;
+};
+
+const formatPositionLabel = (value) => {
+  if (value === null || value === undefined || value === "") return "";
+  const raw = String(value).trim();
+  if (!raw) return "";
+  if (/position/i.test(raw)) return raw;
+  if (/^\d+$/.test(raw)) return `Position ${raw}`;
+  return raw;
+};
+
+const buildSpecText = (source) => {
+  if (source?.specText) return source.specText;
+
+  const thickness = source?.thickness ?? source?.spec?.thickness;
+  const width = source?.width ?? source?.spec?.width;
+  const length = source?.length ?? source?.spec?.length;
+
+  if (thickness && width && length) {
+    return `${thickness} x ${width} x ${length}`;
+  }
+
+  return fallbackPicking.specText;
+};
+
+const normalizePickingData = (source = {}) => {
+  const rawPosition =
+    source?.to?.zone ||
+    source?.toZone ||
+    source?.positionLabel ||
+    source?.targetPositionLabel ||
+    source?.targetPosition ||
+    source?.position ||
+    source?.layout?.highlightedSlot ||
+    fallbackPicking.to.zone;
+
+  const highlightedSlot = String(
+    source?.layout?.highlightedSlot ||
+      source?.highlightedSlot ||
+      extractSlotNumber(rawPosition) ||
+      fallbackPicking.layout.highlightedSlot
+  );
+
+  const toZone =
+    formatPositionLabel(rawPosition) || `Position ${highlightedSlot}`;
+
+  const expectedDurationText =
+    source?.expectedDurationText || source?.duration || fallbackPicking.duration;
+
+  const expectedDurationMinutes =
+    typeof source?.expectedDurationMinutes === "number"
+      ? source.expectedDurationMinutes
+      : parseDurationMinutes(expectedDurationText);
+
+  return {
+    ...fallbackPicking,
+    ...source,
+    manufacturer:
+      source?.manufacturer ||
+      source?.maker ||
+      source?.company ||
+      fallbackPicking.manufacturer,
+    material: source?.material || source?.grade || fallbackPicking.material,
+    specText: buildSpecText(source),
+    weightText:
+      source?.weightText ||
+      source?.weight ||
+      source?.weightKg ||
+      fallbackPicking.weightText,
+    duration: source?.duration || expectedDurationText,
+    expectedDurationText,
+    expectedDurationMinutes,
+    to: {
+      ...fallbackPicking.to,
+      ...(source?.to ?? {}),
+      zone: toZone,
+      time: source?.to?.time || source?.toTime || "",
+    },
+    layout: {
+      ...fallbackPicking.layout,
+      ...(source?.layout ?? {}),
+      highlightedSlot,
+    },
+    pickingOrder:
+      source?.pickingOrder ?? source?.order ?? fallbackPicking.pickingOrder,
+    totalPickingCount:
+      source?.totalPickingCount ??
+      source?.totalCount ??
+      fallbackPicking.totalPickingCount,
+    isLastPicking:
+      typeof source?.isLastPicking === "boolean"
+        ? source.isLastPicking
+        : fallbackPicking.isLastPicking,
+  };
+};
+
+const InfoCard = ({ label, zone, time }) => {
+  return (
+    <div className="flex items-center gap-4 rounded-xl bg-[#ECEEF0] p-4">
+      <div className="rounded-full bg-[#24389C]/10 p-3">
+        <span className="material-symbols-outlined text-[#24389C]">
+          location_on
+        </span>
+      </div>
+
+      <div>
+        <p className="text-xs font-medium uppercase tracking-wider text-[#505F76]">
+          {label}
+        </p>
+        <p className="text-base font-bold text-[#191C1E]">
+          {zone}
+          {time ? (
+            <span className="ml-1 text-xs font-normal text-[#505F76]">
+              {time}
+            </span>
+          ) : null}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+const StepCircle = ({ type = "inactive" }) => {
+  if (type === "done") {
+    return (
+      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-[#24389C]">
+        <span
+          className="material-symbols-outlined text-[14px] text-white"
+          style={{ fontVariationSettings: '"FILL" 1' }}
+        >
+          check
+        </span>
+      </div>
+    );
+  }
+
+  if (type === "active") {
+    return (
+      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-[#24389C] ring-4 ring-[#DEE0FF]">
+        <span
+          className="material-symbols-outlined text-[14px] text-white"
+          style={{ fontVariationSettings: '"FILL" 1' }}
+        >
+          check
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-[#E0E3E5] bg-[#E6E8EA]">
+      <span className="material-symbols-outlined text-[14px] text-[#505F76]">
+        inventory_2
+      </span>
+    </div>
+  );
+};
+
+const LayoutCard = ({ layout, highlightedSlot }) => {
+  const slots = layout?.slots ?? ["1", "2", "3", "4"];
+  const wallLabel = layout?.wallLabel ?? "벽";
+  const equipmentLabel = layout?.equipmentLabel ?? "설비";
+
+  return (
+    <section>
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-lg font-bold text-[#191C1E]">레이아웃</h2>
+      </div>
+
+      <div className="rounded-xl bg-white p-6">
+        <div className="flex justify-center">
+          <div className="relative inline-block min-w-[280px] rounded-lg bg-[#E0E0E0] p-6 pb-12 pr-16">
+            <div className="absolute left-0 right-16 top-0 flex h-12 items-center justify-center rounded-t-lg bg-[#9E9E9E] text-base font-bold text-white">
+              {equipmentLabel}
+            </div>
+
+            <div className="mt-12 grid grid-cols-2 gap-6">
+              {slots.map((slot) => {
+                const isHighlighted = String(slot) === String(highlightedSlot);
+
+                return (
+                  <div
+                    key={slot}
+                    className={`flex h-32 w-24 items-center justify-center border text-2xl font-extrabold shadow-sm ${
+                      isHighlighted
+                        ? "border-transparent text-white shadow-md"
+                        : "border-[#BDBDBD] bg-white text-[#191C1E]"
+                    }`}
+                    style={
+                      isHighlighted
+                        ? { backgroundColor: "rgba(54, 73, 172, 0.86)" }
+                        : undefined
+                    }
+                  >
+                    {slot}
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="absolute bottom-0 right-0 top-0 flex w-16 flex-col items-center justify-center">
+              <div className="h-full w-4 bg-[#191C1E]" />
+              <div className="absolute rounded bg-[#424242] px-2 py-3 text-xs font-bold text-white shadow-sm">
+                {wallLabel}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const DoubleCheckModal = ({ onNo, onYes }) => {
+  return (
+    <>
+      <div className="fixed inset-0 z-[60] bg-black/40 backdrop-blur-md" />
+      <div className="fixed inset-0 z-[70] flex items-center justify-center p-8">
+        <div className="w-full max-w-[320px] rounded-[16px] bg-white p-6 pt-10 shadow-[0_8px_32px_rgba(0,0,0,0.12)]">
+          <h3 className="mb-8 text-center text-[18px] font-bold leading-tight text-[#191C1E]">
+            설비 위에 올리셨습니까?
+          </h3>
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onNo}
+              className="h-[48px] flex-1 rounded-[8px] bg-[#E0E3E5] text-[15px] font-bold text-[#454652] transition-all active:scale-95"
+            >
+              아니오
+            </button>
+
+            <button
+              type="button"
+              onClick={onYes}
+              className="h-[48px] flex-1 rounded-[8px] bg-[#24389C] text-[15px] font-bold text-white shadow-lg shadow-[#24389C]/20 transition-all active:scale-95"
+            >
+              네
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+const CompleteModal = () => {
+  return (
+    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/40 px-6 backdrop-blur-sm">
+      <div className="flex w-full max-w-xs flex-col items-center gap-6 rounded-3xl bg-white p-10 shadow-2xl">
+        <div className="flex h-20 w-20 items-center justify-center rounded-full bg-[#24389C]/10">
+          <span className="material-symbols-outlined text-5xl font-bold text-[#24389C]">
+            check_circle
+          </span>
+        </div>
+
+        <p className="text-center text-xl font-bold leading-tight tracking-tight text-[#191C1E]">
+          이동이 완료되었습니다
+        </p>
+      </div>
+    </div>
+  );
+};
+
+const App_PickingRawPage = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const processedScanKeyRef = useRef("");
+  const completeTimerRef = useRef(null);
+
+  const picking = useMemo(() => {
+    const source =
+      location.state?.picking ||
+      location.state?.item ||
+      location.state?.task ||
+      fallbackPicking;
+
+    return normalizePickingData(source);
+  }, [location.state]);
+
+  const currentPickingOrder =
+    location.state?.pickingOrder ?? picking.pickingOrder ?? 1;
+
+  const totalPickingCount =
+    location.state?.totalPickingCount ?? picking.totalPickingCount ?? 4;
+
+  const isLastPicking =
+    typeof picking.isLastPicking === "boolean" && picking.isLastPicking
+      ? true
+      : currentPickingOrder >= totalPickingCount;
+
+  const [scanState, setScanState] = useState({
+    qrScanned: location.state?.scanState?.qrScanned ?? false,
+    scannedAt: location.state?.scanState?.scannedAt ?? "",
+    toTime: location.state?.scanState?.toTime ?? picking.to?.time ?? "",
+  });
+
+  const [isDoubleCheckOpen, setIsDoubleCheckOpen] = useState(false);
+  const [isCompletePopupOpen, setIsCompletePopupOpen] = useState(false);
+
+  const isCompleted = scanState.qrScanned;
+  const isSaveEnabled = isCompleted;
+
+  const statusText = isCompleted ? "이동 완료" : "이동 중";
+  const progressWidth = isCompleted ? "100%" : "66.6667%";
+  const blurClass =
+    isDoubleCheckOpen || isCompletePopupOpen ? "blur-sm" : "";
+
+  const highlightedSlot = useMemo(() => {
+    return (
+      picking.layout?.highlightedSlot ||
+      extractSlotNumber(picking.to?.zone) ||
+      "1"
+    );
+  }, [picking.layout?.highlightedSlot, picking.to?.zone]);
+
+  const toDisplayTime = scanState.toTime || "";
+
+  const completedPicking = useMemo(() => {
+    return {
+      ...picking,
+      to: {
+        ...picking.to,
+        time: toDisplayTime,
+      },
+    };
+  }, [picking, toDisplayTime]);
+
+  useEffect(() => {
+    const returnedState = location.state;
+    if (!returnedState?.type) return;
+
+    const currentKey = `${location.key}-${returnedState.type}-${returnedState.scannedAt || returnedState?.scanState?.scannedAt || ""}`;
+    if (processedScanKeyRef.current === currentKey) return;
+    processedScanKeyRef.current = currentKey;
+
+    if (returnedState.type === "PICKING_RAW_QR_SUCCESS") {
+      const scannedAt =
+        returnedState?.scanState?.scannedAt ||
+        returnedState?.scannedAt ||
+        formatNowTime();
+
+      const durationMinutes =
+        typeof returnedState?.expectedDurationMinutes === "number"
+          ? returnedState.expectedDurationMinutes
+          : typeof returnedState?.picking?.expectedDurationMinutes === "number"
+            ? returnedState.picking.expectedDurationMinutes
+            : picking.expectedDurationMinutes;
+
+      const nextToTime =
+        returnedState?.scanState?.toTime ||
+        returnedState?.estimatedToTime ||
+        returnedState?.picking?.to?.time ||
+        addMinutesToTime(scannedAt, durationMinutes);
+
+      setScanState({
+        qrScanned: true,
+        scannedAt,
+        toTime: nextToTime,
+      });
+    }
+  }, [location.key, location.state, picking.expectedDurationMinutes]);
+
+  useEffect(() => {
+    if (!isCompletePopupOpen) return;
+
+    const nextPath = isLastPicking ? "/App/processing" : "/App/ready";
+
+    completeTimerRef.current = window.setTimeout(() => {
+      navigate(nextPath, {
+        replace: true,
+        state: {
+          completedPickingId: completedPicking.id,
+          picking: completedPicking,
+          pickingOrder: currentPickingOrder,
+          totalPickingCount,
+        },
+      });
+    }, 1200);
+
+    return () => {
+      if (completeTimerRef.current) {
+        window.clearTimeout(completeTimerRef.current);
+      }
+    };
+  }, [
+    completedPicking,
+    currentPickingOrder,
+    isCompletePopupOpen,
+    isLastPicking,
+    navigate,
+    totalPickingCount,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      if (completeTimerRef.current) {
+        window.clearTimeout(completeTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handlePrevClick = () => {
+    navigate(-1);
+  };
+
+  const handleScanClick = () => {
+    navigate("qr", {
+      relative: "path",
+      state: {
+        ...location.state,
+        returnPath: location.pathname,
+        picking: completedPicking,
+        item: completedPicking,
+        pickingOrder: currentPickingOrder,
+        totalPickingCount,
+        scanState,
+      },
+    });
+  };
+
+  const handleSaveClick = () => {
+    if (!isSaveEnabled) return;
+    setIsDoubleCheckOpen(true);
+  };
+
+  const handleDoubleCheckNo = () => {
+    setIsDoubleCheckOpen(false);
+  };
+
+  const handleDoubleCheckYes = () => {
+    setIsDoubleCheckOpen(false);
+    setIsCompletePopupOpen(true);
+  };
+
+  return (
+    <div className="min-h-screen overflow-x-hidden bg-[#F7F9FB] pb-24 text-[#191C1E]">
+      <header
+        className={`fixed left-0 top-0 z-50 w-full bg-white/80 backdrop-blur-xl ${blurClass}`}
+      >
+        <div className="mx-auto flex h-16 w-full max-w-md items-center justify-between px-6">
+          <div className="flex items-center">
+            <span className="material-symbols-outlined text-2xl text-[#24389C]">
+              factory
+            </span>
+          </div>
+
+          <div className="flex items-center gap-5 text-[#454652]">
+            <button type="button">
+              <span className="material-symbols-outlined text-2xl">
+                notifications
+              </span>
+            </button>
+            <button type="button">
+              <span className="material-symbols-outlined text-2xl">
+                account_circle
+              </span>
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main
+        className={`mx-auto w-full max-w-md space-y-6 px-6 pb-6 pt-24 ${blurClass}`}
+      >
+        <section>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-lg font-bold text-[#191C1E]">원자재 상세 정보</h2>
+          </div>
+
+          <div className="rounded-xl bg-white p-5 shadow-[0_4px_20px_rgba(25,28,30,0.04)]">
+            <div className="grid grid-cols-2 gap-y-4">
+              <div>
+                <p className="mb-1 text-xs font-medium text-[#505F76]">제조사</p>
+                <p className="font-semibold text-[#191C1E]">
+                  {picking.manufacturer}
+                </p>
+              </div>
+
+              <div>
+                <p className="mb-1 text-xs font-medium text-[#505F76]">재질</p>
+                <p className="font-semibold text-[#191C1E]">
+                  {picking.material}
+                </p>
+              </div>
+
+              <div className="col-span-2 pt-2">
+                <p className="mb-1 text-xs font-medium text-[#505F76]">
+                  규격 (두께 x 폭 x 길이)
+                </p>
+                <p className="text-lg font-bold text-[#24389C]">
+                  {picking.specText}
+                </p>
+              </div>
+
+              <div>
+                <p className="mb-1 text-xs font-medium text-[#505F76]">중량</p>
+                <p className="font-semibold text-[#191C1E]">
+                  {picking.weightText}
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid grid-cols-1 gap-4">
+          <InfoCard
+            label="TO"
+            zone={picking.to?.zone}
+            time={toDisplayTime}
+          />
+        </section>
+
+        <section className="flex flex-col items-center py-4">
+          <div className="relative mb-6 flex h-1 w-full max-w-xs items-center rounded-full bg-[#E6E8EA]">
+            <div
+              className="absolute left-0 top-0 h-full rounded-full bg-[#24389C] transition-all"
+              style={{ width: progressWidth }}
+            />
+
+            <div className="absolute inset-0 flex items-center justify-between">
+              <StepCircle type="done" />
+              <StepCircle type={isCompleted ? "done" : "active"} />
+              <StepCircle type={isCompleted ? "done" : "inactive"} />
+            </div>
+          </div>
+
+          <p className="rounded-full bg-[#24389C]/10 px-4 py-1 text-sm font-bold text-[#24389C]">
+            {statusText}
+          </p>
+        </section>
+
+        <section className="relative space-y-4">
+          <div className="flex flex-col items-center rounded-2xl bg-white p-8 text-center shadow-[0_20px_40px_rgba(25,28,30,0.06)]">
+            <div className="relative mb-6 flex h-48 w-48 items-center justify-center overflow-hidden rounded-2xl bg-[#ECEEF0]">
+              <div className="absolute inset-0 flex flex-col items-center justify-center">
+                <span className="material-symbols-outlined text-5xl text-[#24389C]/30">
+                  qr_code_2
+                </span>
+              </div>
+
+              <div className="absolute left-6 top-6 h-8 w-8 rounded-tl-sm border-l-2 border-t-2 border-[#24389C]/40" />
+              <div className="absolute right-6 top-6 h-8 w-8 rounded-tr-sm border-r-2 border-t-2 border-[#24389C]/40" />
+              <div className="absolute bottom-6 left-6 h-8 w-8 rounded-bl-sm border-b-2 border-l-2 border-[#24389C]/40" />
+              <div className="absolute bottom-6 right-6 h-8 w-8 rounded-br-sm border-b-2 border-r-2 border-[#24389C]/40" />
+              <div className="absolute inset-x-10 top-1/2 h-px bg-[#24389C]/20" />
+            </div>
+
+            <div className="w-full">
+              <button
+                type="button"
+                onClick={handleScanClick}
+                disabled={isCompleted}
+                className={`flex w-full items-center justify-center gap-2 rounded-xl py-4 font-bold transition ${
+                  isCompleted
+                    ? "cursor-not-allowed bg-[#E6E8EA] text-[#757684]"
+                    : "bg-gradient-to-br from-[#24389C] to-[#3F51B5] text-white shadow-lg shadow-[#24389C]/20 active:scale-95"
+                }`}
+              >
+                <span className="material-symbols-outlined">
+                  center_focus_weak
+                </span>
+                원자재 scan
+              </button>
+            </div>
+          </div>
+
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={handleSaveClick}
+              disabled={!isSaveEnabled}
+              className={`flex items-center gap-2 rounded-xl px-10 py-4 font-bold transition ${
+                isSaveEnabled
+                  ? "bg-[#1A237E] text-white shadow-lg active:scale-95"
+                  : "cursor-not-allowed bg-[#E6E8EA] text-[#757684]"
+              }`}
+            >
+              <span className="material-symbols-outlined">save</span>
+              저장
+            </button>
+          </div>
+
+          <LayoutCard
+            layout={picking.layout}
+            highlightedSlot={highlightedSlot}
+          />
+        </section>
+      </main>
+
+      <nav
+        className={`fixed bottom-0 left-0 z-50 flex w-full flex-col items-center rounded-t-xl bg-white shadow-[0_-4px_20px_rgba(25,28,30,0.06)] ${blurClass}`}
+      >
+        <button
+          type="button"
+          onClick={handlePrevClick}
+          className="mx-6 my-4 flex w-[calc(100%-3rem)] items-center justify-center gap-2 rounded-xl bg-[#24389C]/10 py-4 text-sm font-semibold uppercase tracking-wider text-[#24389C] transition active:translate-y-0.5"
+        >
+          <span className="material-symbols-outlined">arrow_back</span>
+          Previous
+        </button>
+      </nav>
+
+      {isDoubleCheckOpen ? (
+        <DoubleCheckModal
+          onNo={handleDoubleCheckNo}
+          onYes={handleDoubleCheckYes}
+        />
+      ) : null}
+
+      {isCompletePopupOpen ? <CompleteModal /> : null}
+    </div>
+  );
+};
+
+export default App_PickingRawPage;

--- a/src/pages/field/ReadyPage/App_ReadyPage.jsx
+++ b/src/pages/field/ReadyPage/App_ReadyPage.jsx
@@ -51,7 +51,7 @@ const readyMockData = {
           weightText: "7,698 kg",
           targetPositionLabel: "Position 2",
           infoLabel: "두께×폭",
-          infoValue: "16 × 715",
+          infoValue: "22 × 2,438",
           duration: "6m",
         },
         {
@@ -129,6 +129,24 @@ const parseDurationMinutes = (value) => {
   return plainNumber ? Number(plainNumber[1]) : 0;
 };
 
+const getThicknessWidthTextFromSpec = (specText, fallbackValue = "") => {
+  const raw = String(specText ?? "").trim();
+  if (!raw) return fallbackValue;
+
+  const parts = raw.split(/\s*x\s*/i).map((part) => part.trim());
+  if (parts.length < 2) return fallbackValue;
+
+  return `${parts[0]} × ${parts[1]}`;
+};
+
+const getPickingInfoValue = (item) => {
+  if (item?.type === "원자재" && item?.infoLabel === "두께×폭") {
+    return getThicknessWidthTextFromSpec(item?.specText, item?.infoValue ?? "");
+  }
+
+  return item?.infoValue ?? "";
+};
+
 const SummarySection = ({
   progressPercent,
   remainingTaskCount,
@@ -182,7 +200,7 @@ const RelocateCard = ({ item, onQrClick }) => {
             {item.materialName}
           </h3>
 
-          <div className="mt-1 flex items-center gap-1 text-xs font-medium text-slate-400">
+          <div className="mt-1 flex items-center gap-1 text-xs font-semibold text-slate-500">
             <span>{item.fromZone}</span>
             <span>→</span>
             <span>{item.toZone}</span>
@@ -200,8 +218,10 @@ const RelocateCard = ({ item, onQrClick }) => {
         </button>
       </div>
 
-      <div className="flex items-center gap-1 text-[11px] text-slate-400">
-        <span className="material-symbols-outlined text-xs">schedule</span>
+      <div className="flex items-center gap-1.5 text-[12px] text-slate-400">
+        <span className="material-symbols-outlined text-[18px] leading-none">
+          schedule
+        </span>
         <span>{item.duration}</span>
       </div>
     </div>
@@ -209,6 +229,8 @@ const RelocateCard = ({ item, onQrClick }) => {
 };
 
 const PickingCard = ({ item, onQrClick, onWorkOrderClick }) => {
+  const displayInfoValue = getPickingInfoValue(item);
+
   return (
     <div className="rounded-2xl border border-indigo-100 bg-indigo-50/50 p-4 shadow-sm">
       <div className="mb-2 flex items-start justify-between">
@@ -231,7 +253,7 @@ const PickingCard = ({ item, onQrClick, onWorkOrderClick }) => {
               {item.infoLabel}
             </span>
             <span className="text-[12px] font-bold text-indigo-700">
-              {item.infoValue}
+              {displayInfoValue}
             </span>
           </div>
         </div>
@@ -259,8 +281,10 @@ const PickingCard = ({ item, onQrClick, onWorkOrderClick }) => {
         </div>
       </div>
 
-      <div className="mt-1 flex items-center gap-1 text-[11px] text-slate-400">
-        <span className="material-symbols-outlined text-xs">schedule</span>
+      <div className="mt-1 flex items-center gap-1.5 text-[12px] text-slate-400">
+        <span className="material-symbols-outlined text-[18px] leading-none">
+          schedule
+        </span>
         <span>{item.duration}</span>
       </div>
     </div>

--- a/src/router/App_index.jsx
+++ b/src/router/App_index.jsx
@@ -7,7 +7,7 @@ import App_RelocateQrWipPage from "../pages/field/RelocateQrWipPage/App_Relocate
 import App_RelocateQrZonePage from "../pages/field/RelocateQrZonePage/App_RelocateQrZonePage";
 import App_PickingWipPage from "../pages/field/PickingWipPage/App_PickingWipPage";
 import App_PickingWipQrPage from "../pages/field/PickingWipQrPage/App_PickingWipQrPage";
-// import App_PickingRawPage from "../pages/field/PickingRawPage/App_PickingRawPage";
+import App_PickingRawPage from "../pages/field/PickingRawPage/App_PickingRawPage";
 // import App_PickingRawQrPage from "../pages/field/PickingRawQrPage/App_PickingRawQrPage";
 // import App_ProcessingPage from "../pages/field/ProcessingPage/App_ProcessingPage";
 // import App_ProcessingQrPage from "../pages/field/ProcessingQrPage/App_ProcessingQrPage";
@@ -29,7 +29,7 @@ const appRoutes = [
       { path: "ready/picking/wip", element: <App_PickingWipPage /> },
       { path: "ready/picking/wip/qr", element: <App_PickingWipQrPage /> },
 
-      // { path: "ready/picking/raw", element: <App_PickingRawPage /> },
+      { path: "ready/picking/raw", element: <App_PickingRawPage /> },
       // { path: "ready/picking/raw/qr", element: <App_PickingRawQrPage /> },
 
       // { path: "processing", element: <App_ProcessingPage /> },


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 로그인 기능 구현  
- [Fix] 로그인 API 에러 처리  
- [Refactor] 로그인 UI 코드 개선  

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

원자재의 세부 정보가 화면에 표시된다
제조사, 재질, 두께, 폭, 길이, 중량
하단에 설비 내 레이아웃을 표시하고, 설비 위에 올려야 하는 위치를 강조한다
이때 설비, 벽의 위치를 함께 제시하여 혼선을 방지한다
원자재의 위치 정보는 없으므로 From 은 표시하지 않는다
To 에 이동 정보를 표시하고, 원자재를 스캔할 시 하단에 스캔한 시간을 표시한다 (설비 위에 올라간 시간= 잔재 스캔 시간 + 예상 소요 시간)
설비 공간 위에 올린 후 큐알 활동은 이행하지 않으므로 구역 스캔 버튼은 표시하지 않는다 
잔재 scan이 이루어지지 않으면 저장 버튼이 비활성화된다 
활성화: 진한 보라색
비활성화: 회색 

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

예시:
- Closes #27
- Related to #27
---

## 📸스크린샷 (선택)
<img width="965" height="1495" alt="image" src="https://github.com/user-attachments/assets/9045814e-1bcb-48e4-bd9a-deb8ec9a1f66" />
<img width="1012" height="1513" alt="image" src="https://github.com/user-attachments/assets/e8690d57-d9ed-45cb-8a1e-b7fce74e70a9" />
<img width="891" height="1497" alt="image" src="https://github.com/user-attachments/assets/8c13ee5d-abb7-4359-80dc-eded00e7ac3d" />

---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

예시:
- API 명세 변경사항 포함됨
- 테스트 코드는 다음 PR에서 작성 예정