### PR TITLE
feature/SY2026-94-스캔 시 뒤로가기 및 로고 비활성화

### DIFF
--- a/src/pages/field/PickingWipPage/App_PickingWipPage.jsx
+++ b/src/pages/field/PickingWipPage/App_PickingWipPage.jsx
@@ -335,6 +335,7 @@ const App_PickingWipPage = () => {
 
   const isCompleted = scanState.qrScanned;
   const isSaveEnabled = isCompleted;
+  const isExitLocked = scanState.qrScanned;
 
   const statusText = isCompleted ? "이동 완료" : "이동 중";
   const progressWidth = isCompleted ? "100%" : "66.6667%";
@@ -427,8 +428,9 @@ const App_PickingWipPage = () => {
   ]);
 
   const handlePrevClick = () => {
-    navigate(-1);
-  };
+  if (isExitLocked) return;
+  navigate(-1);
+};
 
   const handleScanClick = () => {
     navigate("qr", {
@@ -473,6 +475,15 @@ const App_PickingWipPage = () => {
   return (
     <div className="h-[100dvh] overflow-hidden bg-[#F7F9FB] text-[#191C1E]">
       <App_Header />
+
+{isExitLocked && (
+  <div
+    className="pointer-events-none fixed left-1/2 top-0 z-[60] h-[72px] w-full max-w-md -translate-x-1/2"
+    aria-hidden="true"
+  >
+    <div className="pointer-events-auto h-full w-[180px]" />
+  </div>
+)}
 
       <main
         className={`mx-auto flex h-[calc(100dvh-72px)] w-full max-w-md flex-col ${blurClass}`}

--- a/src/pages/field/ProcessingQrWipPage/App_ProcessingQrWipPage.jsx
+++ b/src/pages/field/ProcessingQrWipPage/App_ProcessingQrWipPage.jsx
@@ -42,6 +42,7 @@ const App_ProcessingQrWipPage = () => {
   const [isSavePopupOpen, setIsSavePopupOpen] = useState(false);
   const [nextPathAfterSave, setNextPathAfterSave] = useState("/App/processing");
   const [nextStateAfterSave, setNextStateAfterSave] = useState({});
+  const isExitLocked = zoneScanCompleted && !isSavePopupOpen;
 
   const detailData = useMemo(
     () => ({
@@ -133,14 +134,24 @@ const App_ProcessingQrWipPage = () => {
   };
 
   const handlePrevious = () => {
-    navigate(-1);
-  };
+  if (isExitLocked) return;
+  navigate(-1);
+};
 
   const wrapperBlurClass = isSavePopupOpen ? "blur-sm" : "";
 
   return (
     <div className="relative h-[100dvh] overflow-hidden bg-[#f7f9fb] text-slate-900">
       <App_Header />
+
+{isExitLocked && (
+  <div
+    className="pointer-events-none fixed left-1/2 top-0 z-[60] h-[72px] w-full max-w-md -translate-x-1/2"
+    aria-hidden="true"
+  >
+    <div className="pointer-events-auto h-full w-[180px]" />
+  </div>
+)}
 
       <main
   className={`mx-auto flex h-[calc(100dvh-72px)] w-full max-w-md flex-col ${wrapperBlurClass}`}

--- a/src/pages/field/RelocatePage/App_RelocatePage.jsx
+++ b/src/pages/field/RelocatePage/App_RelocatePage.jsx
@@ -116,6 +116,7 @@ const App_RelocatePage = () => {
 
   const isStarted = scanState.wipScanned;
   const isCompleted = scanState.wipScanned && scanState.zoneScanned;
+  const isExitLocked = scanState.wipScanned || scanState.zoneScanned;
 
   const isWipScanEnabled = !scanState.wipScanned;
   const isZoneScanEnabled = scanState.wipScanned && !scanState.zoneScanned;
@@ -174,8 +175,9 @@ const App_RelocatePage = () => {
   }, [location.key, location.state]);
 
   const handlePrevClick = () => {
-    navigate(-1);
-  };
+  if (isExitLocked) return;
+  navigate(-1);
+};
 
   const handleWipScanClick = () => {
     if (!isWipScanEnabled) return;
@@ -215,6 +217,15 @@ const App_RelocatePage = () => {
   return (
     <div className="relative h-[100dvh] overflow-hidden bg-[#f7f9fb] text-slate-900">
       <App_Header />
+
+{isExitLocked && (
+  <div
+    className="pointer-events-none fixed left-1/2 top-0 z-[60] h-[72px] w-full max-w-md -translate-x-1/2"
+    aria-hidden="true"
+  >
+    <div className="pointer-events-auto h-full w-[180px]" />
+  </div>
+)}
 
       <main
   className={`mx-auto flex h-[calc(100dvh-72px)] w-full max-w-md flex-col ${


### PR DESCRIPTION
## 🔀 PR 제목
구역 및 재공품 스캔 하나라도 하면 뒤로가기 및 로고 못 돌아감
적재 큐알 이행 화면에서 구역 스캔 전에는 뒤로가기 가능
---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

예시:
- 로그인 페이지 폼 구현 (이메일/비밀번호 입력)
- 로그인 요청 시 JWT 토큰 발급 및 저장
- 로그인 실패 시 에러 메시지 출력 처리

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

예시:
- Closes #65
- Related to #65
---

## 📸스크린샷 (선택)

---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

예시:
- API 명세 변경사항 포함됨
- 테스트 코드는 다음 PR에서 작성 예정