### PR TITLE
Feature/SY2026-100 재고 상태 가독성 개선

### DIFF
--- a/src/components/office/Web_WipTable/Web_WipTable.jsx
+++ b/src/components/office/Web_WipTable/Web_WipTable.jsx
@@ -2,6 +2,41 @@ function formatNumber(value) {
 	return Number(value).toLocaleString();
 }
 
+function getStatusMeta(status) {
+	switch (status) {
+		case "RESERVATED":
+			return {
+				rowClass: "bg-amber-50/80 hover:bg-amber-50 text-on-surface",
+				qrClass: "text-amber-700",
+				subTextClass: "text-amber-700/80",
+				badgeClass: "bg-amber-100 text-amber-800 border border-amber-200",
+				badgeLabel: "사용 예정",
+				helperText: "생산 계획에 할당된 재고로 현재 사용할 수 없습니다.",
+			};
+
+		case "REGISTERED":
+			return {
+				rowClass: "bg-slate-100/90 hover:bg-slate-100 text-on-surface-variant",
+				qrClass: "text-slate-600",
+				subTextClass: "text-slate-500",
+				badgeClass: "bg-slate-200 text-slate-700 border border-slate-300",
+				badgeLabel: "미적재",
+				helperText: "생산 후 적재 예정인 재공품으로 아직 사용할 수 없습니다.",
+			};
+
+		case "IN_STOCK":
+		default:
+			return {
+				rowClass: "text-on-surface",
+				qrClass: "text-primary",
+				subTextClass: "hidden",
+				badgeClass: "bg-emerald-50 text-emerald-700 border border-emerald-200",
+				badgeLabel: "가용",
+				helperText: "",
+			};
+	}
+}
+
 export default function Web_WipTable({ rows = [] }) {
 	return (
 		<div className="overflow-x-auto">
@@ -29,59 +64,87 @@ export default function Web_WipTable({ rows = [] }) {
 						<th className="px-4 py-4 text-[0.7rem] font-bold text-on-surface-variant uppercase tracking-widest font-label text-right">
 							중량 (kg)
 						</th>
-						<th className="px-4 py-4 text-[0.7rem] font-bold text-on-surface-variant uppercase tracking-widest font-label">
+						<th className="px-4 py-4 text-[0.7rem] font-bold text-on-surface-variant uppercase tracking-widest font-label text-right">
 							위치
 						</th>
-						<th className="px-6 py-4 text-[0.7rem] font-bold text-on-surface-variant uppercase tracking-widest font-label text-center">
+						<th className="px-6 py-4 text-[0.7rem] font-bold text-on-surface-variant uppercase tracking-widest font-label text-right">
 							층
+						</th>
+
+						<th className="px-4 py-4 text-[0.7rem] font-bold text-on-surface-variant uppercase tracking-widest font-label text-center">
+							상태
 						</th>
 					</tr>
 				</thead>
 
-				<tbody className="divide-y-0">
-					{rows.map((row, index) => (
-						<tr
-							key={row.id}
-							className={`group transition-colors hover:bg-surface-container-low ${
-								index % 2 === 1 ? "bg-surface-container-low" : ""
-							}`}
-						>
-							<td className="px-4 py-4 text-sm font-semibold text-primary">
-								{row.qrNumber}
-							</td>
-							<td className="px-4 py-4 text-sm text-on-surface">
-								{row.manufacturer}
-							</td>
-							<td className="px-4 py-4 text-sm text-on-surface">
-								{row.material}
-							</td>
-							<td className="px-4 py-4 text-sm text-on-surface text-right font-mono">
-								{row.thickness}
-							</td>
-							<td className="px-4 py-4 text-sm text-on-surface text-right font-mono">
-								{formatNumber(row.width)}
-							</td>
-							<td className="px-4 py-4 text-sm text-on-surface text-right font-mono">
-								{formatNumber(row.length)}
-							</td>
-							<td className="px-4 py-4 text-sm text-on-surface text-right font-semibold">
-								{formatNumber(row.weight)}
-							</td>
-							<td className="px-4 py-4 text-sm text-on-surface-variant">
-								{row.location}
-							</td>
-							<td className="px-6 py-4 text-center">
-								<span className="text-sm text-on-surface font-medium">
-									{row.layer}
-								</span>
-							</td>
-						</tr>
-					))}
+				<tbody className="divide-y divide-outline-variant/10">
+					{rows.map((row, index) => {
+						const statusMeta = getStatusMeta(row.status);
+						const isDisabledStatus =
+							row.status === "RESERVATED" || row.status === "REGISTERED";
+
+						return (
+							<tr
+								key={row.id}
+								className={`group transition-colors ${
+									index % 2 === 1 && row.status === "IN_STOCK"
+										? "bg-surface-container-low"
+										: ""
+								} ${statusMeta.rowClass}`}
+							>
+								<td className="px-4 py-4">
+									<div className="flex flex-col gap-1">
+										<span
+											className={`text-sm font-semibold ${statusMeta.qrClass}`}
+										>
+											{row.qrNumber}
+										</span>
+										{isDisabledStatus && (
+											<span className={`text-xs ${statusMeta.subTextClass}`}>
+												{statusMeta.helperText}
+											</span>
+										)}
+									</div>
+								</td>
+
+								<td className="px-4 py-4 text-sm">{row.manufacturer}</td>
+
+								<td className="px-4 py-4 text-sm">{row.material}</td>
+
+								<td className="px-4 py-4 text-sm text-right font-mono">
+									{row.thickness}
+								</td>
+
+								<td className="px-4 py-4 text-sm text-right font-mono">
+									{formatNumber(row.width)}
+								</td>
+
+								<td className="px-4 py-4 text-sm text-right font-mono">
+									{formatNumber(row.length)}
+								</td>
+
+								<td className="px-4 py-4 text-sm text-right font-mono">
+									{formatNumber(row.weight)}
+								</td>
+
+								<td className="px-4 py-4 text-sm text-right">{row.location}</td>
+
+								<td className="px-6 py-4 text-sm text-right">{row.layer}</td>
+								<td className="px-4 py-4 text-center">
+									<span
+										className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold ${statusMeta.badgeClass}`}
+									>
+										{statusMeta.badgeLabel}
+									</span>
+								</td>
+							</tr>
+						);
+					})}
 
 					{rows.length === 0 && (
 						<tr>
 							<td
-								colSpan={9}
+								colSpan={10}
 								className="px-6 py-12 text-center text-sm text-on-surface-variant"
 							>
 								조회 결과가 없습니다.

--- a/src/pages/office/Web_WipListPage/Web_WipListPage.jsx
+++ b/src/pages/office/Web_WipListPage/Web_WipListPage.jsx
@@ -139,7 +139,7 @@ export default function Web_WipListPage() {
 	};
 
 	return (
-		<Web_AppLayout title="재고현황">
+		<Web_AppLayout pageTitle="재고현황">
 			<Web_InventoryFilterSection
 				filters={filters}
 				onFilterChange={handleFilterChange}


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 재고 상태 가독성 개선

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

예시:
- 재공품의 Status(In_stock, Registered, Reservated)별 다르게 보일 수 있도록 제작
---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #73
- Related to #73 
---

## 📸스크린샷 (선택)
<img width="1439" height="602" alt="image" src="https://github.com/user-attachments/assets/bde42d0b-382f-4edf-b6a9-7648c2ee6b7b" />
<img width="1429" height="827" alt="image" src="https://github.com/user-attachments/assets/6eaa7dc0-edc2-4327-8eba-35a6232851ee" />

---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.